### PR TITLE
Add support for kernel versions >= 6.4.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+kfocus-keyboard (3.1.4-0kfocus2) jammy; urgency=medium
+
+  * Patch to handle Linux kernel versions >= 6.4.
+    - Fixes https://github.com/kfocus/kfocus-source/issues/17
+
+ -- Aaron Rainbolt <arraybolt3@ubuntu.com>  Thu, 11 Jan 2024 14:41:27 -0600
+
 kfocus-keyboard (3.1.4-0kfocus1) jammy; urgency=medium
 
   * Initial release, fork from tuxedo-keyboard

--- a/debian/patches/linux-6_4-compat.patch
+++ b/debian/patches/linux-6_4-compat.patch
@@ -1,0 +1,26 @@
+Description: Enable compatibility with Linux 6.4+
+ class_create no longer takes a 'struct module *' as a first argument, and
+ instead expects just a string. When building on 6.4+, use the new
+ class_create syntax.
+Author: Aaron Rainbolt <arraybolt3@ubuntu.com>
+Origin: upstream, https://gitlab.com/tuxedocomputers/development/packages/tuxedo-drivers/-/commit/04112f65ec4099d43bca8c00acc61f3a2c0e185f
+Bug-Kfocus: https://github.com/kfocus/kfocus-source/issues/17
+Last-Update: 2024-01-11
+---
+This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
+--- a/src/tuxedo_io/tuxedo_io.c
++++ b/src/tuxedo_io/tuxedo_io.c
+@@ -827,7 +827,13 @@ static int __init tuxedo_io_init(void)
+ 		pr_err("Failed to add cdev\n");
+ 		unregister_chrdev_region(tuxedo_io_device_handle, 1);
+ 	}
++
++#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 4, 0)
+ 	tuxedo_io_device_class = class_create(THIS_MODULE, "tuxedo_io");
++#else
++	tuxedo_io_device_class = class_create("tuxedo_io");
++#endif
++
+ 	device_create(tuxedo_io_device_class, NULL, tuxedo_io_device_handle, NULL, "tuxedo_io");
+ 	pr_debug("Module init successful\n");
+ 	

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,0 +1,1 @@
+linux-6_4-compat.patch


### PR DESCRIPTION
This patch handles a breaking API change introduced in Linux 6.4. If the kernel version is sufficiently new, it uses a new syntax for the `class_create()` function. This is implemented as a Quilt patch in the Debian packaging, leaving the source tree itself untouched.